### PR TITLE
README.md: made the description of .one() clearer

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ To stop listening for the event - simply unbind:
 
     $('div').off('inview');
 
-Remember you can also bind once:
+If you would like the event only to trigger once per element while the page is loaded, you can use the .one() method instead of .on():
 
-    $('div').one('inview', fn);
+    $('div').one('inview', ...);
 
 Live events
 


### PR DESCRIPTION
I was confused as to what "Remember you can also bind once" meant until I tried it.  So I've made a minor adjustment to explain it more clearly.